### PR TITLE
Redirect empty cart and add disabled checkout state

### DIFF
--- a/app/Http/Controllers/Site/SiteController.php
+++ b/app/Http/Controllers/Site/SiteController.php
@@ -190,11 +190,16 @@ class SiteController
             ])->layout(false);
         }
 
-        $customer = customer();
-        $payment_gateways =  Payment::get_available_providers();
         $cart = $cart_service->get_current_cart();
-        $cart = CartResource::make($cart);
 
+        if (! $cart || empty($cart->items) || $cart->items->is_empty()) {
+            wp_safe_redirect(Url::get_cart_url());
+            exit;
+        }
+
+        $customer = customer();
+        $payment_gateways = Payment::get_available_providers();
+        $cart = CartResource::make($cart);
 
         $data = [
             'customer'         => $customer,

--- a/resources/site/scss/components/_button.scss
+++ b/resources/site/scss/components/_button.scss
@@ -44,7 +44,8 @@
 
   &:disabled,
   &[disabled],
-  &[aria-disabled='true'] {
+  &[aria-disabled='true'],
+  &.kecom-btn-disabled {
     cursor: not-allowed;
     opacity: 0.5;
     pointer-events: none;

--- a/resources/views/site/cart/parts/cart-summary.php
+++ b/resources/views/site/cart/parts/cart-summary.php
@@ -27,7 +27,12 @@ $url = user()->is_logged_in() ? $checkout_url : $login_url;
         <span class="kecom-cart-summary-total-title"><?php _e('Estimate Total', 'kirki-ecommerce'); ?></span>
         <span class="kecom-cart-summary-total-value" x-text="cartData.pricing.display_subtotal_money_object.display"></span>
     </div>
-    <a href="<?php echo esc_url($url); ?>" class="kecom-btn kecom-btn-primary kecom-btn-block kecom-cart-summary-checkout-btn">
+    <a
+        href="<?php echo esc_url($url); ?>"
+        class="kecom-btn kecom-btn-primary kecom-btn-block"
+        :class="{ 'kecom-btn-disabled': !cartData.items_count }"
+        :aria-disabled="!cartData.items_count"
+    >
         <?php _e('Proceed to Checkout', 'kirki-ecommerce'); ?>
     </a>
 </div>


### PR DESCRIPTION
Prevent checkout with an empty cart: SiteController now redirects to the cart page if there are no items before building the CartResource. The cart-summary view updates the checkout anchor to bind a 'kecom-btn-disabled' class and aria-disabled via Alpine, disabling the button when items_count is zero. SCSS was updated so the .kecom-btn-disabled class shares the same disabled styles. Minor cleanup: adjusted ordering of customer/payment gateway retrieval.