### PR TITLE
🐛 fix: product search not working

### DIFF
--- a/app/Services/ProductService.php
+++ b/app/Services/ProductService.php
@@ -351,16 +351,10 @@ class ProductService
     protected function apply_filters(QueryBuilder $query, ProductListFilterDTO $filters)
     {
         $query->when($filters->search, function (QueryBuilder $query, $search) {
-            $search = '%' . $search . '%';
-            return $query->where_like('title', $search)->or_where_like('description', $search);
-        });
-
-        $query->where_has('variants', function ($variant_query) use ($filters) {
-            $variant_query->when($filters->search, function ($variant_query) use ($filters) {
-                return $variant_query->where(function ($variant_query) use ($filters) {
-                    $variant_query->where_like('sku', '%' . $filters->search . '%');
-                    return $variant_query;
-                });
+            $like = '%' . $search . '%';
+            return $query->where(function (QueryBuilder $query) use ($like) {
+                $query->where_like('title', $like)
+                    ->or_where_has('variants', fn($variant_query) => $variant_query->where_like('sku', $like));
             });
         });
 

--- a/app/Services/ProductService.php
+++ b/app/Services/ProductService.php
@@ -424,10 +424,6 @@ class ProductService
             return $query->order_by('id', 'desc');
         });
 
-        error_log(
-            print_r($query->get_bindings(), true)
-        );
-
         return $query;
     }
 

--- a/app/Services/ProductService.php
+++ b/app/Services/ProductService.php
@@ -351,7 +351,8 @@ class ProductService
     protected function apply_filters(QueryBuilder $query, ProductListFilterDTO $filters)
     {
         $query->when($filters->search, function (QueryBuilder $query, $search) {
-            return $query->where_any(['title', 'description'], 'like', '%' . $search . '%');
+            $search = '%' . $search . '%';
+            return $query->where_like('title', $search)->or_where_like('description', $search);
         });
 
         $query->where_has('variants', function ($variant_query) use ($filters) {
@@ -422,6 +423,10 @@ class ProductService
 
             return $query->order_by('id', 'desc');
         });
+
+        error_log(
+            print_r($query->get_bindings(), true)
+        );
 
         return $query;
     }


### PR DESCRIPTION
Simplified the search to match the product title and variant SKU when available. Removed the description search because it is a costly operation and can return irrelevant results, especially since product listings may not have descriptions.