### PR TITLE
Add x-local-time directive for client-side dates

### DIFF
--- a/resources/site/ts/directives/local-time.ts
+++ b/resources/site/ts/directives/local-time.ts
@@ -1,0 +1,50 @@
+import { formatLocalDate, parseUtcDate } from '../utils/date';
+
+/**
+ * Alpine directive: x-local-time
+ * Formats UTC ISO strings or timestamps into the user's local timezone.
+ *
+ * Public API:
+ *   x-local-time           -> "Sep 1, 2026, 11:30 AM" (default: datetime)
+ *   x-local-time.date      -> "Sep 1, 2026"
+ *   x-local-time.time      -> "11:30 AM"
+ *   x-local-time.datetime  -> "Sep 1, 2026, 11:30 AM"
+ */
+export function registerLocalTimeDirective(Alpine: any): void {
+  Alpine.directive(
+    'local-time',
+    (
+      el: HTMLElement,
+      { modifiers, expression }: { modifiers: string[]; expression: string },
+      {
+        evaluateLater,
+        effect,
+      }: {
+        evaluateLater: (exp: string) => (cb: (val: any) => void) => void;
+        effect: (fn: () => void) => void;
+      },
+    ) => {
+      const mode = modifiers.includes('date')
+        ? 'date'
+        : modifiers.includes('time')
+          ? 'time'
+          : 'datetime';
+
+      const update = (rawVal: unknown) => {
+        const date = parseUtcDate(rawVal);
+        if (date) {
+          el.textContent = formatLocalDate(date, mode);
+        }
+      };
+
+      if (expression) {
+        const evaluate = evaluateLater(expression);
+        effect(() => {
+          evaluate((val: unknown) => update(val));
+        });
+      } else {
+        update(el.textContent);
+      }
+    },
+  );
+}

--- a/resources/site/ts/index.ts
+++ b/resources/site/ts/index.ts
@@ -25,12 +25,16 @@ import { tabs } from './components/tabs';
 import { variantSelector } from './components/variant-selector';
 
 import { accountOrders } from './components/account-orders';
+import { registerLocalTimeDirective } from './directives/local-time';
 
 import '../scss/index.scss';
 
 // ----------------------------------------------------------------------------
 // Alpine.js Registration
 // ----------------------------------------------------------------------------
+
+// Register directives
+registerLocalTimeDirective(Alpine);
 
 // Register components
 Alpine.data('accountAddresses', accountAddresses);

--- a/resources/site/ts/utils/date.ts
+++ b/resources/site/ts/utils/date.ts
@@ -1,0 +1,68 @@
+export type DateFormatMode = 'date' | 'time' | 'datetime';
+
+/**
+ * Parses a UTC date value (ISO 8601 string, MySQL datetime, timestamp, or Date)
+ * into a valid JavaScript Date object in UTC.
+ */
+export function parseUtcDate(value: unknown): Date | null {
+  if (!value) {
+    return null;
+  }
+  if (value instanceof Date) {
+    return isNaN(value.getTime()) ? null : value;
+  }
+  if (typeof value === 'number') {
+    return new Date(value);
+  }
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const str = value.trim();
+  if (!str) {
+    return null;
+  }
+
+  // Already ISO with explicit Z or timezone offset (+/-HH:MM)
+  if (str.endsWith('Z') || /[+-]\d{2}:\d{2}$/.test(str)) {
+    const d = new Date(str);
+    return isNaN(d.getTime()) ? null : d;
+  }
+
+  // Normalize MySQL format 'YYYY-MM-DD HH:MM:SS' or ISO without timezone to UTC
+  const iso = str.includes('T') ? `${str}Z` : `${str.replace(' ', 'T')}Z`;
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+/**
+ * Formats a Date object using browser's Intl.DateTimeFormat in the user's local timezone.
+ */
+export function formatLocalDate(date: Date, mode: DateFormatMode = 'datetime'): string {
+  const locale = typeof navigator !== 'undefined' ? navigator.language : undefined;
+
+  switch (mode) {
+    case 'date':
+      return new Intl.DateTimeFormat(locale, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      }).format(date);
+
+    case 'time':
+      return new Intl.DateTimeFormat(locale, {
+        hour: 'numeric',
+        minute: 'numeric',
+      }).format(date);
+
+    case 'datetime':
+    default:
+      return new Intl.DateTimeFormat(locale, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+      }).format(date);
+  }
+}

--- a/resources/views/site/account/order-details.php
+++ b/resources/views/site/account/order-details.php
@@ -44,7 +44,7 @@ $order_activities = view_data('activities') ?? [];
 
 $items = $order['items']->to_array() ?? [];
 $items_product_data = $order['item_product_data'] ?? [];
-$order_placed = isset($order['created_at']) ? date('M j, Y', strtotime($order['created_at'])) : '';
+$order_placed = isset($order['created_at']) ? $order['created_at'] : '';
 $shipping_address = $order['shipping_address'] ?? [];
 $shipping_country = $order['shipping_country'] ?? [];
 $shipping_state = array_find($shipping_country['states'] ?? [], fn($item) => $item['id'] == $shipping_address['state']);
@@ -81,7 +81,10 @@ $billing_state = array_find($billing_country['states'] ?? [], fn($item) => $item
                                         <?php echo esc_html($order['payment_status'] === 'paid' ? __('Paid', 'kirki-ecommerce') : __('Unpaid', 'kirki-ecommerce')); ?>
                                     </span>
                                 </div>
-                                <span class="kecom-order-details-placed"><?php echo esc_html(__('Placed on ', 'kirki-ecommerce') . $order_placed); ?></span>
+                                <div class="kecom-order-details-placed">
+                                    <?php esc_html_e('Placed on ', 'kirki-ecommerce'); ?>
+                                    <span x-data x-local-time="'<?php echo esc_js($order_placed); ?>'"></span>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -99,14 +102,14 @@ $billing_state = array_find($billing_country['states'] ?? [], fn($item) => $item
                                                 <div class="kecom-order-step <?php echo 0 === $key ? 'kecom-order-step-active' : '' ?> <?php echo $timeline['activity_type'] === OrderActivityType::DELIVERED ? 'kecom-order-step-delivered' : '' ?>">
                                                     <div class="kecom-order-step-indicator">
                                                         <?php if($timeline['activity_type'] === OrderActivityType::DELIVERED) : ?>
-                                                            <?php Icon::render('check'); ?>
+                                                             <?php Icon::render('check'); ?>
                                                         <?php else: ?>
                                                             <span class="kecom-order-step-dot"></span>
                                                         <?php endif; ?>
                                                     </div>
                                                     <div class="kecom-order-step-content">
                                                         <h4 class="kecom-order-step-title"><?php echo esc_html(OrderActivityType::get_formatted($timeline['activity_type']) ?? ''); ?></h4>
-                                                        <span class="kecom-order-step-date"><?php echo esc_html($timeline['created_at']->format(DateTimeFormats::HUMAN_READABLE_DATE_TIME)); ?></span>
+                                                        <span class="kecom-order-step-date" x-data x-local-time="'<?php echo esc_js($timeline['created_at']); ?>'"></span>
                                                     </div>
                                                 </div>
                                         <?php endforeach; ?>

--- a/resources/views/site/order-success.php
+++ b/resources/views/site/order-success.php
@@ -59,9 +59,7 @@ $total_money_object = $totals['invoiced_total_money_object'];
                     </div>
                     <div class="kecom-order-success-row">
                         <div class="kecom-order-success-row-key"><?php _e('Order Time', 'kirki-ecommerce'); ?></div>
-                        <div class="kecom-order-success-row-value">
-                            <?php echo esc_html(date_i18n(get_option('date_format') . ' ' . get_option('time_format'), $order['created_at']->get_timestamp())); ?>
-                        </div>
+                        <div class="kecom-order-success-row-value" x-data x-local-time="'<?php echo esc_js($order['created_at']); ?>'"></div>
                     </div>
                     <div class="kecom-order-success-row">
                         <div class="kecom-order-success-row-key"><?php _e('Payment Method', 'kirki-ecommerce'); ?></div>


### PR DESCRIPTION
Add client-side local timezone formatting using an Alpine directive.

- Added utils/date.ts (parseUtcDate, formatLocalDate) and directives/local-time.ts which formats UTC ISO/timestamps into user's local timezone (modes: date, time, datetime).
- Registered directive in resources/site/ts/index.ts.
- Updated PHP views to emit raw timestamps and use x-local-time (order-details.php, order-success.php) instead of server-side formatted strings.
- Minor whitespace fix in order-details.php.

This moves presentation of order times to the browser so times render in the visitor's locale.