### PR TITLE
[Chore] Fix add-to-cart quantity validation and refactor variant availability lookup

### DIFF
--- a/app/Actions/Account/UpdateAccountAddressesAction.php
+++ b/app/Actions/Account/UpdateAccountAddressesAction.php
@@ -57,15 +57,15 @@ class UpdateAccountAddressesAction
         try {
             $address_data = $data->all();
 
+            $this->customer_service->set_billing_same_as_shipping($customer->id, $data->is_billing_same_as_shipping ?? false);
+
             if ($data->type === AddressType::BILLING && $data->is_billing_same_as_shipping && !empty($customer->shipping_address)) {
-                $this->customer_service->set_billing_same_as_shipping($customer->id, $data->is_billing_same_as_shipping);
                 $address_data = $customer->shipping_address->to_array();
             }
 
             if ($data->type === AddressType::BILLING && $data->is_billing_same_as_shipping && empty($customer->shipping_address)) {
                 throw new Exception(__('Shipping address is not set.', 'kirki-ecommerce'));
             }
-                
 
             $this->update_address($customer, $address_data, $data->type);
 

--- a/app/Actions/Cart/AddToCartAction.php
+++ b/app/Actions/Cart/AddToCartAction.php
@@ -6,6 +6,7 @@ use Kirki\Ecommerce\App\Services\CartService;
 use Kirki\Ecommerce\App\Services\InventoryService;
 use Kirki\Ecommerce\App\Services\VariantService;
 use Kirki\Ecommerce\App\DTO\Cart\AddToCartDTO;
+use Kirki\Ecommerce\App\DTO\Cart\CreateCartItemDTO;
 use Exception;
 
 class AddToCartAction
@@ -32,18 +33,33 @@ class AddToCartAction
             throw new Exception(__('Variant not found.', 'kirki-ecommerce'));
         }
 
-        if (!$this->inventory_service->has_stock($dto->variant_id, $dto->quantity)) {
+        $dto->product_id = $variant->product_id;
+
+        $cart = $this->cart_service->get_cart($dto->user_id, $dto->token);
+        $existing_item = $cart ? $this->cart_service->find_item_in_cart($cart->id, $dto->variant_id) : null;
+        $resulting_quantity = $existing_item ? $existing_item->quantity + $dto->quantity : $dto->quantity;
+
+        if (!$this->inventory_service->has_stock($dto->variant_id, $resulting_quantity)) {
             throw new Exception(__('Not enough stock for this variant', 'kirki-ecommerce'));
         }
 
-        if (!$this->inventory_service->is_within_limit($dto->variant_id, $dto->quantity)) {
-            throw new Exception(sprintf(__('You can not add more than %d units of this item to cart', 'kirki-ecommerce'), $dto->variant_id));
+        if (!$this->inventory_service->is_within_limit($dto->variant_id, $resulting_quantity)) {
+            throw new Exception(sprintf(__('You can not add more than %d units of this item to cart', 'kirki-ecommerce'), $variant->max_per_order));
         }
 
-        $dto->product_id = $variant->product_id;
+        $cart = $cart ?: $this->cart_service->get_or_create_cart($dto->user_id, $dto->token);
 
-        $cart = $this->cart_service->add_item($dto);
+        if ($existing_item) {
+            $this->cart_service->update_item_quantity($cart->id, $existing_item->id, $resulting_quantity);
+        } else {
+            $this->cart_service->add_item_to_cart(CreateCartItemDTO::from_array([
+                'cart_id' => $cart->id,
+                'product_id' => $dto->product_id,
+                'variant_id' => $dto->variant_id,
+                'quantity' => $dto->quantity,
+            ]));
+        }
 
-        return $cart;
+        return $this->cart_service->find($cart->id);
     }
 }

--- a/app/DTO/Cart/CreateCartItemDTO.php
+++ b/app/DTO/Cart/CreateCartItemDTO.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Kirki\Ecommerce\App\DTO\Cart;
+
+use Kirki\Ecommerce\Framework\DTO;
+
+class CreateCartItemDTO extends DTO
+{
+    /**
+     * @var int
+     */
+    public $cart_id;
+
+    /**
+     * @var int
+     */
+    public $product_id;
+
+    /**
+     * @var int
+     */
+    public $variant_id;
+
+    /**
+     * @var int
+     */
+    public $quantity;
+}

--- a/app/Resources/Variant/VariantResource.php
+++ b/app/Resources/Variant/VariantResource.php
@@ -25,10 +25,7 @@ class VariantResource extends Resource
         $availability_service = app()->make(AvailabilityService::class);
         $store_default_threshold = (int) Settings::get('product.low_stock_threshold', 0);
         $availability_status = $availability_service->resolve_variant_status(
-            $this->track_inventory,
-            $this->in_stock,
-            $this->available_quantity,
-            $this->low_stock_threshold,
+            $this->resource,
             $store_default_threshold
         );
 

--- a/app/Services/AvailabilityService.php
+++ b/app/Services/AvailabilityService.php
@@ -3,33 +3,31 @@
 namespace Kirki\Ecommerce\App\Services;
 
 use Kirki\Ecommerce\App\Constants\Product\AvailabilityStatus;
+use Kirki\Ecommerce\App\Models\Variant;
 
 class AvailabilityService
 {
     /**
      * Resolve a single variant's stock state (Layer 1).
      *
-     * @param bool $track_inventory
-     * @param bool $in_stock
-     * @param int $available_quantity
-     * @param int|null $low_stock_threshold The variant's own threshold, or null to fall back to the store default.
+     * @param Variant $variant
      * @param int $store_default_threshold
      *
      * @return string One of AvailabilityStatus::IN_STOCK|LOW_STOCK|OUT_OF_STOCK
      */
-    public function resolve_variant_status($track_inventory, $in_stock, $available_quantity, $low_stock_threshold, $store_default_threshold)
+    public function resolve_variant_status(Variant $variant, int $store_default_threshold = 0)
     {
-        if (!$track_inventory) {
-            return $in_stock ? AvailabilityStatus::IN_STOCK : AvailabilityStatus::OUT_OF_STOCK;
+        if (!$variant->track_inventory) {
+            return $variant->in_stock ? AvailabilityStatus::IN_STOCK : AvailabilityStatus::OUT_OF_STOCK;
         }
 
-        if ($available_quantity <= 0) {
+        if ($variant->available_quantity <= 0) {
             return AvailabilityStatus::OUT_OF_STOCK;
         }
 
-        $threshold = is_null($low_stock_threshold) ? $store_default_threshold : $low_stock_threshold;
+        $threshold = is_null($variant->low_stock_threshold) ? $store_default_threshold : $variant->low_stock_threshold;
 
-        if ($available_quantity <= $threshold) {
+        if ($variant->available_quantity <= $threshold) {
             return AvailabilityStatus::LOW_STOCK;
         }
 
@@ -82,13 +80,7 @@ class AvailabilityService
         $statuses = [];
 
         foreach ($variants as $variant) {
-            $statuses[] = $this->resolve_variant_status(
-                $variant->track_inventory,
-                $variant->in_stock,
-                $variant->available_quantity,
-                $variant->low_stock_threshold,
-                $store_default_threshold
-            );
+            $statuses[] = $this->resolve_variant_status($variant, $store_default_threshold);
         }
 
         return $this->resolve_group_status($statuses);

--- a/app/Services/CartService.php
+++ b/app/Services/CartService.php
@@ -4,7 +4,7 @@ namespace Kirki\Ecommerce\App\Services;
 
 use Exception;
 use Kirki\Ecommerce\App\Constants\Cart as CartConstants;
-use Kirki\Ecommerce\App\DTO\Cart\AddToCartDTO;
+use Kirki\Ecommerce\App\DTO\Cart\CreateCartItemDTO;
 use Kirki\Ecommerce\App\DTO\Cart\EmptyCartDTO;
 use Kirki\Ecommerce\App\DTO\Cart\RemoveCartItemDTO;
 use Kirki\Ecommerce\App\Models\Cart as CartModel;
@@ -54,6 +54,25 @@ class CartService
         }
 
         return $guest_cart;
+    }
+
+    /**
+     * Resolve the canonical cart for the given identity, creating a new
+     * one if none exists.
+     *
+     * @param int|null $user_id
+     * @param string|null $token
+     * @return CartModel
+     */
+    public function get_or_create_cart($user_id = null, $token = null)
+    {
+        $cart = $this->get_cart($user_id, $token);
+
+        if (empty($cart)) {
+            $cart = $this->create_new_cart($user_id);
+        }
+
+        return $cart;
     }
 
     protected function resolve_owned_cart(int $user_id, ?string $token = null)
@@ -137,9 +156,9 @@ class CartService
         return $this->find($id);
     }
 
-    protected function add_item_to_cart($cart_id, array $item_data)
+    public function add_item_to_cart(CreateCartItemDTO $dto)
     {
-        return CartItem::create(array_merge(['cart_id' => $cart_id], $item_data));
+        return CartItem::create($dto->to_array());
     }
 
     protected function create_new_cart($user_id = null)
@@ -170,32 +189,6 @@ class CartService
         return CartItem::where('cart_id', $cart_id)
             ->where('variant_id', $variant_id)
             ->first();
-    }
-
-    public function add_item(AddToCartDTO $dto)
-    {
-        $cart = $this->get_cart($dto->user_id, $dto->token);
-
-        if (empty($cart)) {
-            $cart = $this->create_new_cart($dto->user_id);
-        }
-
-        $cart_id = $cart->id;
-
-        $existing_item = $this->find_item_in_cart($cart_id, $dto->variant_id);
-
-        if ($existing_item) {
-            $new_quantity = $existing_item->quantity + $dto->quantity;
-            $this->update_item_quantity($cart_id, $existing_item->id, $new_quantity);
-        } else {
-            $this->add_item_to_cart($cart_id, [
-                'product_id' => $dto->product_id,
-                'variant_id' => $dto->variant_id,
-                'quantity' => $dto->quantity,
-            ]);
-        }
-
-        return $this->find($cart_id);
     }
 
     public function update_item_quantity($cart_id, $item_id, $quantity)

--- a/openspec/changes/archive/2026-09-01-fix-add-to-cart-quantity-validation/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-01-fix-add-to-cart-quantity-validation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/archive/2026-09-01-fix-add-to-cart-quantity-validation/design.md
+++ b/openspec/changes/archive/2026-09-01-fix-add-to-cart-quantity-validation/design.md
@@ -1,0 +1,55 @@
+## Context
+
+See [proposal.md](proposal.md) for motivation. Relevant current state:
+
+- `AddToCartAction::execute()` validates `has_stock($variant_id, $dto->quantity)` and `is_within_limit($variant_id, $dto->quantity)`, then calls `CartService::add_item($dto)`.
+- `CartService::add_item()` resolves the cart (`get_cart()`, creating one via the protected `create_new_cart()` if none exists), looks up any existing cart item for the variant via `find_item_in_cart()`, and either merges into it (`update_item_quantity`) or creates a new line (the protected `add_item_to_cart()`). This merge decision is invisible to the Action.
+- `UpdateCartItemAction` already has the correct shape for comparison: it fetches the target item, validates `has_stock`/`is_within_limit` against `$dto->quantity` directly (that DTO field is an absolute set, not a delta), then calls the already-public `update_item_quantity()`. No merge ambiguity exists there because there's nothing to merge.
+- `CartService::add_item()` is called directly, bypassing `AddToCartAction` and its validation, from three test call sites: `tests/Integration/CartApiTest.php:499`, `tests/Integration/OrderApiTest.php:1031`, `tests/Integration/OrderApiTest.php:1077`.
+- No unique constraint exists on `(cart_id, variant_id)` in `kirki_ecommerce_cart_items`, and no transaction/row lock wraps the read-check-write sequence.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Validate stock and per-order limit against the cart line's *resulting* quantity (existing + requested), for both the "line already exists" and "new line" cases.
+- Have exactly one place per request that decides "does this item already exist in the cart" — used for both validation and the write — instead of the Action and the Service each independently re-deriving it.
+- Keep `CartService` as a persistence-only layer (no `InventoryService` dependency, no stock/limit business rules) and `AddToCartAction` as the sole owner of that validation, consistent with `UpdateCartItemAction`.
+
+**Non-Goals:**
+- Closing the concurrent-request race (two simultaneous requests both reading "no existing line" before either writes). Tracked as an explicit follow-up per the proposal; this change does not add locking, transactions, or a unique constraint for that purpose.
+- Changing the `POST /cart/items` request/response contract.
+- Changing `UpdateCartItemAction` — its validation is already correct.
+
+## Decisions
+
+### Split `CartService::add_item()` into standalone public primitives, rather than making `add_item_to_cart()` public as-is
+
+Considered and rejected: leaving `add_item()` in place and having the Action separately call `find_item_in_cart()` before calling `add_item()`, purely to compute the total for validation. Rejected because it leaves two independent lookups deciding the same "does this item exist" question (one in the Action for validation, one inside `add_item()` for the write) with nothing enforcing they agree — the exact shape of bug this change fixes, just moved one level down.
+
+Chosen approach: remove `add_item()`. Extract its cart-resolution half into a new public `CartService::get_or_create_cart($user_id, $token)`. Change `add_item_to_cart()` from `protected` to `public` (kept as its own primitive rather than merged into something else, since `find_item_in_cart` / `update_item_quantity` / `add_item_to_cart` together already form a complete, minimal CRUD surface). `AddToCartAction` calls `find_item_in_cart()` exactly once, uses that single result both to compute the validation total and to decide which write primitive to call.
+
+Alternative considered: give `CartService` a single `upsert_item($cart_id, $variant_id, $product_id, $quantity)` that takes the final, already-validated quantity and internally branches merge-vs-create. Rejected: it would re-run `find_item_in_cart()` a second time inside the Service to do that branching, reintroducing a second lookup (a minor cost, but with no offsetting benefit — `update_item_quantity`/`add_item_to_cart` already exist as public primitives and this pattern is what `UpdateCartItemAction` already uses elsewhere).
+
+### `get_or_create_cart()` is a genuine Service-level primitive, not new business logic
+
+Cart resolution (find-or-create a cart for a user/token) is lifecycle plumbing, not a policy decision — unlike stock/limit checks, it doesn't decide whether a mutation is *allowed*. It belongs in `CartService` for the same reason `get_cart()` already does. `create_new_cart()` stays `protected`, called only from the new `get_or_create_cart()`, since nothing outside `CartService` needs to force-create a cart without first checking for an existing one.
+
+### Test call sites switch to `AddToCartAction`
+
+The three integration tests calling `CartService::add_item()` directly are seeding cart state to test unrelated flows (order placement, coupons), not testing add-to-cart validation itself. Since `add_item()` no longer exists, they call `AddToCartAction::execute()` instead — this is strictly more correct, since it means those tests seed state through the same validated path production traffic uses, rather than a shortcut that (per this change) had a bug in it.
+
+### Correction during implementation: `add_item_to_cart()` takes a DTO, not `($cart_id, array $item_data)`
+
+The task list had `add_item_to_cart()` keep its existing `($cart_id, array $item_data)` shape and just go from `protected` to `public`. That was inconsistent with the rest of the codebase: every other Service's `create()` method (`TagService`, `VariantService`, `ProductService`, `CouponService`, `AddressService`, etc.) takes a typed `CreateXDTO`, not a raw array — `CartService`'s array-based methods are the outlier, not the norm, and making one of them public without fixing that just exported the inconsistency. Added `App\DTO\Cart\CreateCartItemDTO` (`cart_id`, `product_id`, `variant_id`, `quantity`) and changed `add_item_to_cart()` to `add_item_to_cart(CreateCartItemDTO $dto)`, internally `CartItem::create($dto->to_array())` — the same `to_array()`-off-the-base-`DTO`-class pattern `TagService::create()` already uses.
+
+### Correction during implementation: cart creation is deferred until after validation
+
+The task list originally had `AddToCartAction` resolve the cart via `get_or_create_cart()` up front, before validation, so it could look up any existing item to compute the resulting quantity. In practice this created a persisted, empty cart (and set a guest cookie) as a side effect of a *rejected* add-to-cart request — a regression from current behavior, where validation runs entirely before `CartService` is touched. Caught by `test_add_item_rejects_single_call_exceeding_limit` (a brand-new cart scenario): `GET /cart` returned a cart record instead of nothing after the rejected request.
+
+Fixed by splitting cart resolution in two: a read-only `get_cart()` lookup up front (returns `null` if none exists, used only to find any existing item for the quantity calculation), and `get_or_create_cart()` deferred until immediately before the write, called only once validation has passed. No new capability was needed for this — `get_cart()` was already public.
+
+## Risks / Trade-offs
+
+- **[Risk]** `add_item_to_cart()` becoming `public` widens `CartService`'s API surface. → **Mitigation**: it's a narrow, single-purpose primitive (`create a cart item row`) with no business-rule leakage — same shape as the already-public `update_item_quantity()`.
+- **[Risk]** Test churn at three call sites could mask an unrelated failure if `AddToCartAction`'s validation now rejects a fixture that `add_item()` previously accepted unconditionally. → **Mitigation**: check each fixture's quantity against seeded stock/limit while updating the call sites; adjust fixture data if needed rather than working around the validation.
+- **[Trade-off]** The concurrent-request race is explicitly not addressed here (see Non-Goals). This change fixes the sequential/repeated-click case described in the proposal; true simultaneous requests for the same variant can still both pass validation before either writes.

--- a/openspec/changes/archive/2026-09-01-fix-add-to-cart-quantity-validation/proposal.md
+++ b/openspec/changes/archive/2026-09-01-fix-add-to-cart-quantity-validation/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+`AddToCartAction` validates stock and per-order limits against the incoming `quantity` only, not against the quantity the cart line will actually hold after merging with any existing item. Adding to an already-populated cart line in multiple calls (e.g. clicking "Add to cart" repeatedly) can silently push a variant's cart quantity past its stock or its `max_per_order` limit, because each call only checks its own delta against the limit, never the resulting total.
+
+## What Changes
+
+- `AddToCartAction` computes the cart line's *resulting* quantity (existing quantity + requested quantity) before validating stock and per-order limits, instead of validating the requested quantity in isolation.
+- `CartService::add_item()` is removed. Its two responsibilities — resolving/creating the cart, and merging-or-creating the cart item — are split into standalone public primitives so the Action can validate against the same lookup it uses to write, with no duplicated or hidden merge decision:
+  - `CartService::get_or_create_cart($user_id, $token)` (new, extracted from the current internal logic in `add_item()`)
+  - `CartService::add_item_to_cart(CreateCartItemDTO $dto)` (visibility changed from `protected` to `public`; signature changed from `($cart_id, array $item_data)` to a typed `CreateCartItemDTO`, matching the DTO-based `create()` convention used by every other Service in this codebase — see design.md)
+  - `CartService::find_item_in_cart()` and `CartService::update_item_quantity()` (already public, unchanged)
+- `AddToCartAction` orchestrates: resolve cart → look up existing item → compute total → validate stock/limit against the total → write via `update_item_quantity` (merge) or `add_item_to_cart` (new line).
+- Test call sites that previously called `CartService::add_item()` directly to seed cart state now go through `AddToCartAction`, so integration tests exercise the same validated path as production traffic.
+- **BREAKING**: `CartService::add_item()` is removed. Any code calling it directly must call `AddToCartAction::execute()` instead.
+
+Out of scope for this change: concurrent (simultaneous) add-to-cart requests for the same variant can still both pass validation before either writes, since there is no transaction/row lock or unique constraint backing this check-then-write. That race is tracked as a follow-up.
+
+## Capabilities
+
+### New Capabilities
+- `cart-item-quantity-limits`: Defines how the backend validates a cart line's resulting quantity — after merging with any existing quantity for that variant — against available stock and the variant's configured per-order limit when items are added to the cart.
+
+### Modified Capabilities
+(none — no existing spec currently covers add-to-cart stock/limit validation)
+
+## Impact
+
+- `app/Actions/Cart/AddToCartAction.php` — validation logic rewritten to check the resulting total quantity.
+- `app/Services/CartService.php` — `add_item()` removed; `get_or_create_cart()` added; `add_item_to_cart()` visibility changed to `public` and its signature changed to take a `CreateCartItemDTO`.
+- `app/DTO/Cart/CreateCartItemDTO.php` — new DTO (`cart_id`, `product_id`, `variant_id`, `quantity`).
+- `tests/Integration/CartApiTest.php`, `tests/Integration/OrderApiTest.php` — call sites using `CartService::add_item()` switched to `AddToCartAction`.
+- No API contract change: the `POST /cart/items` request/response shape is unchanged, only the validation now checks the correct value.

--- a/openspec/changes/archive/2026-09-01-fix-add-to-cart-quantity-validation/specs/cart-item-quantity-limits/spec.md
+++ b/openspec/changes/archive/2026-09-01-fix-add-to-cart-quantity-validation/specs/cart-item-quantity-limits/spec.md
@@ -1,0 +1,48 @@
+## Purpose
+
+Defines how the system validates a cart line's quantity against available stock and the variant's configured per-order limit whenever a shopper adds a variant to their cart.
+
+## ADDED Requirements
+
+### Requirement: Stock validation considers the cart line's resulting quantity
+When a shopper adds a variant to their cart, the system SHALL validate available stock against the quantity the cart line will hold after the addition (existing quantity for that variant in the cart, if any, plus the requested quantity) — not the requested quantity alone.
+
+#### Scenario: Adding to an empty cart line within stock
+- **WHEN** a shopper adds a variant not already in their cart, and the requested quantity does not exceed available stock
+- **THEN** the item is added to the cart
+
+#### Scenario: Adding to an existing cart line within stock
+- **WHEN** a shopper adds a variant already in their cart, and the existing quantity plus the requested quantity does not exceed available stock
+- **THEN** the cart line's quantity is increased by the requested amount
+
+#### Scenario: Addition would exceed available stock once merged with the existing line
+- **WHEN** a shopper adds a variant already in their cart, and the existing quantity plus the requested quantity exceeds available stock, even though the requested quantity alone does not
+- **THEN** the system rejects the addition with an insufficient-stock error
+- **AND** the cart line's quantity is unchanged
+
+### Requirement: Per-order limit validation considers the cart line's resulting quantity
+When a shopper adds a variant to their cart, and that variant has a configured per-order limit, the system SHALL validate the limit against the quantity the cart line will hold after the addition (existing quantity for that variant in the cart, if any, plus the requested quantity) — not the requested quantity alone.
+
+#### Scenario: Adding to an existing cart line within the limit
+- **WHEN** a shopper adds a variant already in their cart that has a per-order limit, and the existing quantity plus the requested quantity does not exceed that limit
+- **THEN** the cart line's quantity is increased by the requested amount
+
+#### Scenario: Addition would exceed the per-order limit once merged with the existing line
+- **WHEN** a shopper adds a variant already in their cart that has a per-order limit, and the existing quantity plus the requested quantity exceeds that limit, even though the requested quantity alone does not
+- **THEN** the system rejects the addition with a limit-exceeded error
+- **AND** the cart line's quantity is unchanged
+
+#### Scenario: Variant without a configured limit is unaffected
+- **WHEN** a shopper adds a variant that has no per-order limit configured
+- **THEN** the addition is not rejected on limit grounds, regardless of the resulting cart line quantity
+
+### Requirement: Rejected additions do not partially mutate the cart
+When an add-to-cart request fails stock or per-order limit validation, the system SHALL leave the cart and its existing items unchanged.
+
+#### Scenario: Failed validation leaves an existing line untouched
+- **WHEN** an add-to-cart request for a variant already in the cart fails stock or limit validation
+- **THEN** the existing cart line's quantity remains at its pre-request value
+
+#### Scenario: Failed validation does not create a new line
+- **WHEN** an add-to-cart request for a variant not yet in the cart fails stock or limit validation
+- **THEN** no cart line is created for that variant

--- a/openspec/changes/archive/2026-09-01-fix-add-to-cart-quantity-validation/tasks.md
+++ b/openspec/changes/archive/2026-09-01-fix-add-to-cart-quantity-validation/tasks.md
@@ -1,0 +1,35 @@
+## 1. `CartService` primitives
+
+- [x] 1.1 Add public `get_or_create_cart($user_id, $token)`, extracting the current `get_cart()` ?: `create_new_cart()` logic out of `add_item()`.
+- [x] 1.2 Change `add_item_to_cart($cart_id, array $item_data)` visibility from `protected` to `public`. (Revised further: signature changed to `add_item_to_cart(CreateCartItemDTO $dto)` — see "Correction during implementation" in design.md.)
+- [x] 1.3 Remove `add_item(AddToCartDTO $dto)` entirely.
+- [x] 1.4 Verify: `composer test:unit`
+
+## 2. `AddToCartAction` orchestration
+
+- [x] 2.1 Resolve the cart via `cart_service->get_or_create_cart($dto->user_id, $dto->token)`.
+- [x] 2.2 Look up any existing line via `cart_service->find_item_in_cart($cart->id, $dto->variant_id)`.
+- [x] 2.3 Compute the resulting quantity: `existing ? $existing->quantity + $dto->quantity : $dto->quantity`.
+- [x] 2.4 Validate `has_stock()` and `is_within_limit()` against the resulting quantity (not `$dto->quantity` alone).
+- [x] 2.5 On success, write via `update_item_quantity()` when a line already existed, or `add_item_to_cart()` when it did not.
+- [x] 2.6 Return the cart via `cart_service->find($cart->id)`, matching current return behavior.
+- [x] 2.7 Verify: `composer test:unit`
+
+## 3. Migrate direct `CartService::add_item()` callers
+
+- [x] 3.1 Update the cart-seeding helper in `tests/Integration/CartApiTest.php` (around line 499) to call `AddToCartAction::execute()` instead of `CartService::add_item()`.
+- [x] 3.2 Update both call sites in `tests/Integration/OrderApiTest.php` (around lines 1031 and 1077) the same way.
+- [x] 3.3 For each updated call site, confirm the fixture's seeded quantity still passes stock/limit validation now that it runs through `AddToCartAction`; adjust fixture data if a previously-unvalidated seed would now be rejected. (All call sites seed quantity 1-2 against the default test-product fixture: `available_quantity = 100`, no `max_per_order` configured — no adjustment needed.)
+- [x] 3.4 Verify: `composer test:integration` (run via `composer test:docker:integration` — no local WP test env installed; 240 tests, 4691 assertions, all passing)
+
+## 4. Regression coverage for the fixed bug
+
+- [x] 4.1 Add an integration test: two sequential add-to-cart calls for the same variant whose combined quantity exceeds `max_per_order` — second call is rejected, and the cart line's quantity is unchanged from after the first call.
+- [x] 4.2 Add an integration test: two sequential add-to-cart calls for the same variant whose combined quantity exceeds available stock — second call is rejected, and the cart line's quantity is unchanged from after the first call. (Required setting `track_inventory => true` on the fixture — `CreateVariantDTO` defaults it to `false`, which short-circuits `has_stock()` to always-true regardless of `available_quantity`.)
+- [x] 4.3 Add an integration test: a single add-to-cart call for a variant not yet in the cart, requesting more than `max_per_order` (or more than available stock) in one shot, is still rejected (guards against regressing the already-working single-call case). (Caught a real regression: see "Correction during implementation" in design.md — cart resolution had to be deferred until after validation so a rejected first-ever add-to-cart doesn't persist an empty cart as a side effect.)
+- [x] 4.4 Verify: `composer test:integration` (via `composer test:docker:integration` filtered to `CartApiTest` — 17 tests, 662 assertions, all passing)
+
+## 5. Final verification
+
+- [x] 5.1 Run the full suite: `composer test` (via `composer test:docker:unit` + `composer test:docker:integration` — 173 unit tests / 281 assertions, 243 integration tests / 4807 assertions, all passing)
+- [x] 5.2 Grep the codebase for any remaining reference to `CartService::add_item` to confirm no caller was missed. (Only `CartService::add_item_to_cart` remains, which is the intended public primitive.)

--- a/openspec/specs/cart-item-quantity-limits/spec.md
+++ b/openspec/specs/cart-item-quantity-limits/spec.md
@@ -1,0 +1,48 @@
+# cart-item-quantity-limits Specification
+
+## Purpose
+Defines how the system validates a cart line's quantity against available stock and the variant's configured per-order limit whenever a shopper adds a variant to their cart.
+## Requirements
+### Requirement: Stock validation considers the cart line's resulting quantity
+When a shopper adds a variant to their cart, the system SHALL validate available stock against the quantity the cart line will hold after the addition (existing quantity for that variant in the cart, if any, plus the requested quantity) — not the requested quantity alone.
+
+#### Scenario: Adding to an empty cart line within stock
+- **WHEN** a shopper adds a variant not already in their cart, and the requested quantity does not exceed available stock
+- **THEN** the item is added to the cart
+
+#### Scenario: Adding to an existing cart line within stock
+- **WHEN** a shopper adds a variant already in their cart, and the existing quantity plus the requested quantity does not exceed available stock
+- **THEN** the cart line's quantity is increased by the requested amount
+
+#### Scenario: Addition would exceed available stock once merged with the existing line
+- **WHEN** a shopper adds a variant already in their cart, and the existing quantity plus the requested quantity exceeds available stock, even though the requested quantity alone does not
+- **THEN** the system rejects the addition with an insufficient-stock error
+- **AND** the cart line's quantity is unchanged
+
+### Requirement: Per-order limit validation considers the cart line's resulting quantity
+When a shopper adds a variant to their cart, and that variant has a configured per-order limit, the system SHALL validate the limit against the quantity the cart line will hold after the addition (existing quantity for that variant in the cart, if any, plus the requested quantity) — not the requested quantity alone.
+
+#### Scenario: Adding to an existing cart line within the limit
+- **WHEN** a shopper adds a variant already in their cart that has a per-order limit, and the existing quantity plus the requested quantity does not exceed that limit
+- **THEN** the cart line's quantity is increased by the requested amount
+
+#### Scenario: Addition would exceed the per-order limit once merged with the existing line
+- **WHEN** a shopper adds a variant already in their cart that has a per-order limit, and the existing quantity plus the requested quantity exceeds that limit, even though the requested quantity alone does not
+- **THEN** the system rejects the addition with a limit-exceeded error
+- **AND** the cart line's quantity is unchanged
+
+#### Scenario: Variant without a configured limit is unaffected
+- **WHEN** a shopper adds a variant that has no per-order limit configured
+- **THEN** the addition is not rejected on limit grounds, regardless of the resulting cart line quantity
+
+### Requirement: Rejected additions do not partially mutate the cart
+When an add-to-cart request fails stock or per-order limit validation, the system SHALL leave the cart and its existing items unchanged.
+
+#### Scenario: Failed validation leaves an existing line untouched
+- **WHEN** an add-to-cart request for a variant already in the cart fails stock or limit validation
+- **THEN** the existing cart line's quantity remains at its pre-request value
+
+#### Scenario: Failed validation does not create a new line
+- **WHEN** an add-to-cart request for a variant not yet in the cart fails stock or limit validation
+- **THEN** no cart line is created for that variant
+

--- a/tests/Integration/CartApiTest.php
+++ b/tests/Integration/CartApiTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirki\Ecommerce\Tests\Integration;
 
+use Kirki\Ecommerce\App\Actions\Cart\AddToCartAction;
 use Kirki\Ecommerce\App\Constants\Cart;
 use Kirki\Ecommerce\App\Constants\Coupon\CouponMethod;
 use Kirki\Ecommerce\App\Constants\Coupon\CustomerExcludeEligibility;
@@ -119,6 +120,116 @@ class CartApiTest extends RestTestCase
         $this->assertEquals(2, $payload['items'][0]['quantity']);
 
         $this->cart_item_id = $payload['items'][0]['id'];
+    }
+
+    /**
+     * Two sequential add-to-cart calls whose combined quantity exceeds the
+     * variant's per-order limit are rejected on the call that crosses it,
+     * even though each call's own quantity is within the limit.
+     *
+     * @return void
+     */
+    public function test_add_item_rejects_when_cumulative_quantity_exceeds_limit(): void
+    {
+        $product = $this->create_product([
+            'variants' => [[
+                'base_price' => 29.99,
+                'sku' => 'SKU-' . wp_generate_password(6, false),
+                'available_quantity' => 100,
+                'in_stock' => true,
+                'is_default' => true,
+                'attribute_values' => [],
+                'has_limit_per_order' => true,
+                'max_per_order' => 3,
+            ]],
+        ]);
+        $this->variant_id = $this->default_variant_id($product);
+
+        $cart = $this->add_cart_item(2);
+        $this->assertEquals(2, $cart['items'][0]['quantity']);
+
+        $response = $this->request('POST', 'cart/items', [
+            'variant_id' => $this->variant_id,
+            'quantity' => 2,
+        ], $this->cart_headers);
+
+        $this->assert_api_error($response, 500);
+
+        $current = $this->assert_api_success($this->request('GET', 'cart', [], $this->cart_headers))['data'];
+        $this->assertCount(1, $current['items']);
+        $this->assertEquals(2, $current['items'][0]['quantity']);
+    }
+
+    /**
+     * Two sequential add-to-cart calls whose combined quantity exceeds
+     * available stock are rejected on the call that crosses it, even though
+     * each call's own quantity is within stock.
+     *
+     * @return void
+     */
+    public function test_add_item_rejects_when_cumulative_quantity_exceeds_stock(): void
+    {
+        $product = $this->create_product([
+            'variants' => [[
+                'base_price' => 29.99,
+                'sku' => 'SKU-' . wp_generate_password(6, false),
+                'available_quantity' => 3,
+                'in_stock' => true,
+                'track_inventory' => true,
+                'is_default' => true,
+                'attribute_values' => [],
+            ]],
+        ]);
+        $this->variant_id = $this->default_variant_id($product);
+
+        $cart = $this->add_cart_item(2);
+        $this->assertEquals(2, $cart['items'][0]['quantity']);
+
+        $response = $this->request('POST', 'cart/items', [
+            'variant_id' => $this->variant_id,
+            'quantity' => 2,
+        ], $this->cart_headers);
+
+        $this->assert_api_error($response, 500);
+
+        $current = $this->assert_api_success($this->request('GET', 'cart', [], $this->cart_headers))['data'];
+        $this->assertCount(1, $current['items']);
+        $this->assertEquals(2, $current['items'][0]['quantity']);
+    }
+
+    /**
+     * A single add-to-cart call that alone exceeds the per-order limit is
+     * still rejected, guarding against regressing the already-working
+     * single-call case while fixing the cumulative one.
+     *
+     * @return void
+     */
+    public function test_add_item_rejects_single_call_exceeding_limit(): void
+    {
+        $product = $this->create_product([
+            'variants' => [[
+                'base_price' => 29.99,
+                'sku' => 'SKU-' . wp_generate_password(6, false),
+                'available_quantity' => 100,
+                'in_stock' => true,
+                'is_default' => true,
+                'attribute_values' => [],
+                'has_limit_per_order' => true,
+                'max_per_order' => 3,
+            ]],
+        ]);
+        $this->variant_id = $this->default_variant_id($product);
+
+        $response = $this->request('POST', 'cart/items', [
+            'variant_id' => $this->variant_id,
+            'quantity' => 5,
+        ], $this->cart_headers);
+
+        $this->assert_api_error($response, 500);
+
+        $current = $this->request('GET', 'cart', [], $this->cart_headers);
+        $payload = $this->assert_api_success($current)['data'];
+        $this->assertEmpty($payload);
     }
 
     /**
@@ -496,7 +607,7 @@ class CartApiTest extends RestTestCase
         $dto->quantity = $quantity;
         $dto->user_id = $user_id;
 
-        return app()->make(CartService::class)->add_item($dto);
+        return app()->make(AddToCartAction::class)->execute($dto);
     }
 
     protected function raw_cart(array $overrides = [])

--- a/tests/Integration/OrderApiTest.php
+++ b/tests/Integration/OrderApiTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirki\Ecommerce\Tests\Integration;
 
+use Kirki\Ecommerce\App\Actions\Cart\AddToCartAction;
 use Kirki\Ecommerce\App\Actions\Customer\CreateCustomerAction;
 use Kirki\Ecommerce\App\Actions\Order\CreateOrderAction;
 use Kirki\Ecommerce\App\Constants\AddressType;
@@ -1028,7 +1029,7 @@ class OrderApiTest extends RestTestCase
         $add_to_cart_dto->variant_id = $variant_id;
         $add_to_cart_dto->quantity = 1;
 
-        $cart = app()->make(CartService::class)->add_item($add_to_cart_dto);
+        $cart = app()->make(AddToCartAction::class)->execute($add_to_cart_dto);
         $cart_token = $cart->cart_token;
 
         $this->assertNotNull(Cart::where('cart_token', $cart_token)->first());
@@ -1074,7 +1075,7 @@ class OrderApiTest extends RestTestCase
         $add_to_cart_dto->variant_id = $this->variant_id;
         $add_to_cart_dto->quantity = 1;
 
-        $guest_cart = app()->make(CartService::class)->add_item($add_to_cart_dto);
+        $guest_cart = app()->make(AddToCartAction::class)->execute($add_to_cart_dto);
         $cart_token = $guest_cart->cart_token;
         $user_id = $this->create_shopper_user();
 

--- a/tests/Unit/Services/AvailabilityServiceTest.php
+++ b/tests/Unit/Services/AvailabilityServiceTest.php
@@ -3,6 +3,7 @@
 namespace Kirki\Ecommerce\Tests\Unit\Services;
 
 use Kirki\Ecommerce\App\Constants\Product\AvailabilityStatus;
+use Kirki\Ecommerce\App\Models\Variant;
 use Kirki\Ecommerce\App\Services\AvailabilityService;
 use Kirki\Ecommerce\Tests\Unit\TestCase;
 
@@ -21,57 +22,102 @@ class AvailabilityServiceTest extends TestCase
 
     public function test_untracked_variant_in_stock_flag_true_is_in_stock(): void
     {
-        $status = $this->service->resolve_variant_status(false, true, 0, null, 0);
+        $status = $this->service->resolve_variant_status(new Variant([
+            'track_inventory' => false,
+            'in_stock' => true,
+            'available_quantity' => 0,
+            'low_stock_threshold' => null,
+        ]), 0);
 
         $this->assertSame(AvailabilityStatus::IN_STOCK, $status);
     }
 
     public function test_untracked_variant_in_stock_flag_false_is_out_of_stock(): void
     {
-        $status = $this->service->resolve_variant_status(false, false, 999, null, 0);
+        $status = $this->service->resolve_variant_status(new Variant([
+            'track_inventory' => false,
+            'in_stock' => false,
+            'available_quantity' => 999,
+            'low_stock_threshold' => null,
+        ]), 0);
 
         $this->assertSame(AvailabilityStatus::OUT_OF_STOCK, $status);
     }
 
     public function test_tracked_variant_at_zero_quantity_is_out_of_stock(): void
     {
-        $status = $this->service->resolve_variant_status(true, true, 0, null, 5);
+        $status = $this->service->resolve_variant_status(new Variant([
+            'track_inventory' => true,
+            'in_stock' => true,
+            'available_quantity' => 0,
+            'low_stock_threshold' => null,
+        ]), 5);
 
         $this->assertSame(AvailabilityStatus::OUT_OF_STOCK, $status);
     }
 
     public function test_tracked_variant_at_threshold_is_low_stock(): void
     {
-        $status = $this->service->resolve_variant_status(true, true, 3, 3, 0);
+        $status = $this->service->resolve_variant_status(new Variant([
+            'track_inventory' => true,
+            'in_stock' => true,
+            'available_quantity' => 3,
+            'low_stock_threshold' => 3,
+        ]), 0);
 
         $this->assertSame(AvailabilityStatus::LOW_STOCK, $status);
     }
 
     public function test_tracked_variant_above_threshold_is_in_stock(): void
     {
-        $status = $this->service->resolve_variant_status(true, true, 4, 3, 0);
+        $status = $this->service->resolve_variant_status(new Variant([
+            'track_inventory' => true,
+            'in_stock' => true,
+            'available_quantity' => 4,
+            'low_stock_threshold' => 3,
+        ]), 0);
 
         $this->assertSame(AvailabilityStatus::IN_STOCK, $status);
     }
 
     public function test_zero_threshold_never_yields_low_stock(): void
     {
-        $status = $this->service->resolve_variant_status(true, true, 1, 0, 5);
+        $status = $this->service->resolve_variant_status(new Variant([
+            'track_inventory' => true,
+            'in_stock' => true,
+            'available_quantity' => 1,
+            'low_stock_threshold' => 0,
+        ]), 5);
 
         $this->assertSame(AvailabilityStatus::IN_STOCK, $status);
     }
 
     public function test_back_order_at_zero_quantity_still_reports_out_of_stock(): void
     {
-        $status = $this->service->resolve_variant_status(true, true, 0, null, 0);
+        $status = $this->service->resolve_variant_status(new Variant([
+            'track_inventory' => true,
+            'in_stock' => true,
+            'available_quantity' => 0,
+            'low_stock_threshold' => null,
+        ]), 0);
 
         $this->assertSame(AvailabilityStatus::OUT_OF_STOCK, $status);
     }
 
     public function test_null_threshold_falls_back_to_store_default(): void
     {
-        $low_stock = $this->service->resolve_variant_status(true, true, 5, null, 5);
-        $in_stock = $this->service->resolve_variant_status(true, true, 6, null, 5);
+        $low_stock = $this->service->resolve_variant_status(new Variant([
+            'track_inventory' => true,
+            'in_stock' => true,
+            'available_quantity' => 5,
+            'low_stock_threshold' => null,
+        ]), 5);
+        $in_stock = $this->service->resolve_variant_status(new Variant([
+            'track_inventory' => true,
+            'in_stock' => true,
+            'available_quantity' => 6,
+            'low_stock_threshold' => null,
+        ]), 5);
 
         $this->assertSame(AvailabilityStatus::LOW_STOCK, $low_stock);
         $this->assertSame(AvailabilityStatus::IN_STOCK, $in_stock);
@@ -79,7 +125,12 @@ class AvailabilityServiceTest extends TestCase
 
     public function test_explicit_zero_threshold_does_not_fall_back_to_store_default(): void
     {
-        $status = $this->service->resolve_variant_status(true, true, 5, 0, 5);
+        $status = $this->service->resolve_variant_status(new Variant([
+            'track_inventory' => true,
+            'in_stock' => true,
+            'available_quantity' => 5,
+            'low_stock_threshold' => 0,
+        ]), 5);
 
         $this->assertSame(AvailabilityStatus::IN_STOCK, $status);
     }
@@ -174,8 +225,8 @@ class AvailabilityServiceTest extends TestCase
     public function test_resolve_product_status_combines_both_layers(): void
     {
         $variants = [
-            (object) ['track_inventory' => true, 'in_stock' => true, 'available_quantity' => 10, 'low_stock_threshold' => null],
-            (object) ['track_inventory' => true, 'in_stock' => true, 'available_quantity' => 0, 'low_stock_threshold' => null],
+            new Variant(['track_inventory' => true, 'in_stock' => true, 'available_quantity' => 10, 'low_stock_threshold' => null]),
+            new Variant(['track_inventory' => true, 'in_stock' => true, 'available_quantity' => 0, 'low_stock_threshold' => null]),
         ];
 
         $status = $this->service->resolve_product_status($variants, 0);


### PR DESCRIPTION
Add-to-cart validated stock and per-order limits against the requested quantity in isolation, so repeated adds of the same variant could push a cart line past its limit without ever being rejected. AddToCartAction now validates against the resulting cart line quantity (existing + requested); CartService::add_item() is removed in favor of separate public primitives (get_or_create_cart, add_item_to_cart) so the Action can validate and write off a single lookup instead of two independent ones. add_item_to_cart now takes a typed CreateCartItemDTO, matching every other Service's create() convention in this codebase.

Also simplifies AvailabilityService::resolve_variant_status() to take a Variant model instead of four loose scalar parameters, and fixes UpdateAccountAddressesAction to always sync billing-same-as-shipping instead of only when the billing address is also being set to match shipping.